### PR TITLE
Add examples for authentication, paging, and handling rate limits

### DIFF
--- a/api-common-usage/python/auth.py
+++ b/api-common-usage/python/auth.py
@@ -1,0 +1,116 @@
+from threading import Lock
+import logging
+import time
+
+import requests
+
+from exception import ApiAuthError
+
+AUTH_URL = 'https://api.smartling.com/auth-api/v2/authenticate'
+REFRESH_URL = 'https://api.smartling.com/auth-api/v2/authenticate/refresh'
+TIME_BUFFER = 10 # seconds
+
+class Authenticator:
+
+    def __init__(self, user_identifier, user_secret):
+        self._user_identifier = user_identifier
+        self._user_secret = user_secret
+        self._lock = Lock()
+        self._clear_data()
+
+
+    def _clear_data(self):
+        self._access_token = None
+        self._refresh_token = None
+        self._access_expires_at = None
+        self._refresh_expires_at = None
+
+
+    def get_access_token(self):
+        if self._token_is_valid():
+            return self._access_token
+        else:
+            return self._create_or_refresh_token()
+
+
+    def _token_is_valid(self):
+        if self._access_token and time.time() < self._access_expires_at:
+            return True
+        else:
+            return False
+
+
+    def _create_or_refresh_token(self):
+        with self._lock:
+            if self._token_is_valid():
+                return self._access_token
+
+            if self._refresh_token and time.time() < self._refresh_expires_at:
+                return self._call_refresh()
+            else:
+                return self._call_authenticate()
+
+
+    def _call_refresh(self):
+        try:
+            logging.debug('Refreshing token')
+
+            r = requests.post(REFRESH_URL, json = {'refreshToken': self._refresh_token})
+
+        except requests.exceptions.RequestException as e:
+            
+            logging.error('HTTP error calling {0}'.format(REFRESH_URL))
+            logging.error(e)
+            raise ApiAuthError('Refresh call failed. Check log for details.')
+
+        if r.status_code == 200:
+            return self._parse_response(r)
+
+        elif r.status_code == 401:
+            # shouldn't happen; try reauthenticating
+            return self._call_authenticate()
+
+        else:
+            self._clear_data()
+            logging.error('Error calling {0}. Status code: {1}. Response {2}'.format(REFRESH_URL,
+                                                                                     r.status_code,
+                                                                                     r.text))
+            raise ApiAuthError('Refresh call error. Please check log for details.')
+
+
+    def _call_authenticate(self):
+        try:
+            logging.debug('Authenticating.')
+
+            r = requests.post(AUTH_URL, json = {'userIdentifier': self._user_identifier,
+                                                'userSecret': self._user_secret})
+
+        except requests.exceptions.RequestException as e:
+
+            logging.error('HTTP error calling {0}'.format(AUTH_URL))
+            logging.error(e)
+            raise ApiAuthError('Authentication call failed. Check log for details.')
+
+
+        if r.status_code == 200:
+            return self._parse_response(r)
+
+        else:
+            self._clear_data()
+            logging.error('Error calling {0}. Status code: {1}. Response {2}'.format(AUTH_URL,
+                                                                                     r.status_code,
+                                                                                     r.text))
+            raise ApiAuthError('Authentication call error. Please check log for details.')
+
+
+    def _parse_response(self, r):
+
+            self._access_token = r.json()['response']['data']['accessToken']
+            self._refresh_token = r.json()['response']['data']['refreshToken']
+            expires_in = r.json()['response']['data']['expiresIn']
+            self._access_expires_at = time.time() + expires_in - TIME_BUFFER
+            refresh_expires_in = r.json()['response']['data']['refreshExpiresIn']
+            self._refresh_expires_at = time.time() + refresh_expires_in - TIME_BUFFER
+
+            return self._access_token
+

--- a/api-common-usage/python/exception.py
+++ b/api-common-usage/python/exception.py
@@ -1,0 +1,5 @@
+class ApiError(Exception):
+    pass
+
+class ApiAuthError(ApiError):
+    pass

--- a/api-common-usage/python/list-files.py
+++ b/api-common-usage/python/list-files.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python3
+
+import json
+import logging
+import os
+import sys
+import time
+
+import requests
+
+import auth
+import exception
+
+MAX_RETRIES = 10
+
+
+def get_files_one_page(offset, limit, project_id, authenticator):
+
+    api_url = 'https://api.smartling.com/files-api/v2/projects/{0}/files/list'.format(project_id)
+    params = {
+        'orderBy': 'created_asc',
+        'offset': offset,
+        'limit': limit
+    }
+
+    # loop to handle retries if Smartling rate limiting encountered
+    for attempt in range(MAX_RETRIES):
+
+        try:
+            # get access token inside retry loop in case it expires during retry attempts
+            headers = {'Authorization': 'Bearer ' + authenticator.get_access_token()}
+
+            resp = requests.get(api_url, headers = headers, params = params)
+
+        # (should really check for specific exceptions here in case some can be handled)
+        except requests.exceptions.RequestException as e:
+            logging.error('HTTP error calling {0}'.format(api_url))
+            logging.error(e)
+            raise exception.ApiError('Call to get files failed. Check the log for details.')
+
+
+        if resp.status_code == 429: 
+            # rate limited; sleep for a while before retrying
+            logging.warning('Received 429 rate-limit response.' )
+            randomized_exponential_delay = (2 ** attempt) + random.random()
+            time_to_sleep = min(randomized_exponential_delay, MAX_DELAY)
+            time.sleep(time_to_sleep)
+
+        else:
+            # not rate limited, so no need to retry
+            break
+
+
+    if resp.status_code == 200:
+        return resp.json()['response']['data']['items']
+
+    else:
+        logging.error('Error calling {0}. Status code: {1}. Response: {2}'.format(api_url,
+                                                                                  resp.status_code,
+                                                                                  resp.text))
+        raise exception.ApiError('Get-Files call error. Check log for details.')
+
+
+
+def get_files(project_id, authenticator):
+
+    results = []
+
+    offset = 0  # start at the first item
+    limit = 100 # page size
+    # loop to page through results
+    while True: 
+        items = get_files_one_page(offset, limit, project_id, authenticator)
+
+        count = len(items)
+        results.extend(items)
+
+        if count < limit:
+            # response contained fewer than we asked for, so we must be at the end
+            break
+
+        else:
+            # continue loop to get another page
+            offset += count 
+            
+    return results
+
+
+def main():
+
+    logging.basicConfig(filename='example.log', encoding='utf-8', level=logging.INFO)
+    
+    project_id = 'x'#os.environ.get('DEV_PROJECT_ID')
+    user_id = os.environ.get('DEV_USER_IDENTIFIER')
+    user_secret = os.environ.get('DEV_USER_SECRET')
+
+    if (project_id is None) or (user_id is None) or (user_secret is None):
+
+        print('Missing environment variables. Did you run setenv?')
+        sys.exit()
+
+    authenticator = auth.Authenticator(user_id, user_secret)
+    
+    try:
+        file_list = get_files(project_id, authenticator)
+
+        for file in file_list:
+            print(file['fileUri'])
+
+        print('File count: {0}'.format(len(file_list)))            
+
+    except exception.ApiError as error:
+
+        logging.exception(error)
+        print(error)
+        
+
+if __name__ == '__main__':
+    main()
+
+


### PR DESCRIPTION
Example Python code to illustrate handling of authentication/refresh, paging through long result sets, and handling rate-limited responses. This example doesn't use any of the SDKs, but the same example will be added for each of the SDKs too.

The authentication code is roughly based on the approach used in the Java SDK.